### PR TITLE
fix: correct INDERTERMINATED to INTERMINATED in ResultTestEnum (issue #20)

### DIFF
--- a/dmp-evaluator-service/src/main/kotlin/io/github/ostrails/dmpevaluatorservice/model/ResultTestEnum.kt
+++ b/dmp-evaluator-service/src/main/kotlin/io/github/ostrails/dmpevaluatorservice/model/ResultTestEnum.kt
@@ -4,6 +4,6 @@ enum class ResultTestEnum {
     PASS,
     FAIL,
     ERROR,
-    INDERTERMINATED,
+    INTERMINATED,
     NOT_APPLICABLE
 }


### PR DESCRIPTION
Fixes the typo INDERTERMINATED → INTERMINATED in ResultTestEnum.kt (issue #20). 1 file, 1 line.